### PR TITLE
Use NamedTemporaryFile instead of .inTer1, 2, 3

### DIFF
--- a/src/fortran/KreatE_inter_m_f.f90
+++ b/src/fortran/KreatE_inter_m_f.f90
@@ -7,7 +7,7 @@ function crear_int0(NX,NY,STARTLAT,STARTLON,DELTALAT,DELTALON,int1,fci,int2,int3
     integer, parameter :: OUNIT = 11
 
     integer :: NVARS
-    character(len=200) :: NS
+    character(len=*) :: NS
 
 
     integer :: VERSION = 5
@@ -18,18 +18,18 @@ function crear_int0(NX,NY,STARTLAT,STARTLON,DELTALAT,DELTALON,int1,fci,int2,int3
     character(len=8) :: STARTLOC = 'SWCORNER'
 
     character(len=9) :: FIELD
-    character(len=10) :: int1
+    character(len=*) :: int1
     character(len=9), dimension(NVARS) :: fint
 
     character(len=24) :: fci
 
 
     character(len=25) :: UNITS
-    character(len=10) :: int2
+    character(len=*) :: int2
     character(len=25), dimension(NVARS) :: funt
 
     character(len=46) :: DESC
-    character(len=10) :: int3
+    character(len=*) :: int3
     character(len=46), dimension(NVARS) :: fdes
 
     character(len=32):: MAP_SOURCE = 'PYWINTER'
@@ -104,7 +104,7 @@ function crear_int1(NX,NY,STARTLAT,STARTLON,DX,DY,TRUELAT1,int1,fci,int2,int3,fl
     integer, parameter :: OUNIT = 11
 
     integer :: NVARS
-    character(len=200) :: NS
+    character(len=*) :: NS
 
 
     integer :: VERSION = 5
@@ -115,18 +115,18 @@ function crear_int1(NX,NY,STARTLAT,STARTLON,DX,DY,TRUELAT1,int1,fci,int2,int3,fl
     character(len=8) :: STARTLOC = 'SWCORNER'
 
     character(len=9) :: FIELD
-    character(len=10) :: int1
+    character(len=*) :: int1
     character(len=9), dimension(NVARS) :: fint
 
     character(len=24) :: fci
 
 
     character(len=25) :: UNITS
-    character(len=10) :: int2
+    character(len=*) :: int2
     character(len=25), dimension(NVARS) :: funt
 
     character(len=46) :: DESC
-    character(len=10) :: int3
+    character(len=*) :: int3
     character(len=46), dimension(NVARS) :: fdes
 
     character(len=32):: MAP_SOURCE = 'PYWINTER'
@@ -201,7 +201,7 @@ function crear_int3(NX,NY,STARTLAT,STARTLON,DX,DY,XLONC,TRUELAT1,TRUELAT2,iswin,
     integer, parameter :: OUNIT = 11
 
     integer :: NVARS
-    character(len=200) :: NS
+    character(len=*) :: NS
 
 
     integer :: VERSION = 5
@@ -212,18 +212,18 @@ function crear_int3(NX,NY,STARTLAT,STARTLON,DX,DY,XLONC,TRUELAT1,TRUELAT2,iswin,
     character(len=8) :: STARTLOC = 'SWCORNER'
 
     character(len=9) :: FIELD
-    character(len=10) :: int1
+    character(len=*) :: int1
     character(len=9), dimension(NVARS) :: fint
 
     character(len=24) :: fci
 
 
     character(len=25) :: UNITS
-    character(len=10) :: int2
+    character(len=*) :: int2
     character(len=25), dimension(NVARS) :: funt
 
     character(len=46) :: DESC
-    character(len=10) :: int3
+    character(len=*) :: int3
     character(len=46), dimension(NVARS) :: fdes
 
     character(len=32):: MAP_SOURCE = 'PYWINTER'
@@ -301,7 +301,7 @@ function crear_int4(NX,NY,STARTLAT,STARTLON,NLATS,DELTALON,iswin,int1,fci,int2,i
     integer, parameter :: OUNIT = 11
 
     integer :: NVARS
-    character(len=200) :: NS
+    character(len=*) :: NS
 
 
     integer :: VERSION = 5
@@ -312,18 +312,18 @@ function crear_int4(NX,NY,STARTLAT,STARTLON,NLATS,DELTALON,iswin,int1,fci,int2,i
     character(len=8) :: STARTLOC = 'SWCORNER'
 
     character(len=9) :: FIELD
-    character(len=10) :: int1
+    character(len=*) :: int1
     character(len=9), dimension(NVARS) :: fint
 
     character(len=24) :: fci
 
 
     character(len=25) :: UNITS
-    character(len=10) :: int2
+    character(len=*) :: int2
     character(len=25), dimension(NVARS) :: funt
 
     character(len=46) :: DESC
-    character(len=10) :: int3
+    character(len=*) :: int3
     character(len=46), dimension(NVARS) :: fdes
 
     character(len=32):: MAP_SOURCE = 'PYWINTER'
@@ -398,7 +398,7 @@ function crear_int5(NX,NY,STARTLAT,STARTLON,DX,DY,XLONC,TRUELAT1,iswin,int1,fci,
     integer, parameter :: OUNIT = 11
 
     integer :: NVARS
-    character(len=200) :: NS
+    character(len=*) :: NS
 
 
     integer :: VERSION = 5
@@ -409,18 +409,18 @@ function crear_int5(NX,NY,STARTLAT,STARTLON,DX,DY,XLONC,TRUELAT1,iswin,int1,fci,
     character(len=8) :: STARTLOC = 'SWCORNER'
 
     character(len=9) :: FIELD
-    character(len=10) :: int1
+    character(len=*) :: int1
     character(len=9), dimension(NVARS) :: fint
 
     character(len=24) :: fci
 
 
     character(len=25) :: UNITS
-    character(len=10) :: int2
+    character(len=*) :: int2
     character(len=25), dimension(NVARS) :: funt
 
     character(len=46) :: DESC
-    character(len=10) :: int3
+    character(len=*) :: int3
     character(len=46), dimension(NVARS) :: fdes
 
     character(len=32):: MAP_SOURCE = 'PYWINTER'

--- a/src/pywinter/winter.py
+++ b/src/pywinter/winter.py
@@ -206,7 +206,7 @@ class Interm:
                     fds,
                     flv,
                     ns,
-                    va
+                    va,
                 )
 
             elif isinstance(self.geos, Geo03):

--- a/src/pywinter/winter.py
+++ b/src/pywinter/winter.py
@@ -1,11 +1,13 @@
 import numpy as np
 import os
 from struct import unpack
+from tempfile import NamedTemporaryFile
 import pywinter.KreatE_inter_m_f as creattee_inter
 
 
 # COMPILE
 # f2py -c KreatE_inter_m_f.f90 -m KreatE_inter_m_f
+
 
 class Interm:
     def __init__(
@@ -137,7 +139,6 @@ class Interm:
             tlat1 = self.geoinfo["TRUELAT1"]
             iswin = self.geoinfo["IS_WIND_EARTH_REL"]
 
-
         if self.nocolons:
             ns = self.rout + self.filen + "_" + self.hdat
         else:
@@ -154,90 +155,101 @@ class Interm:
 
         va = self.megamat
 
-        file1 = open(".inTer1", "w")
-        file2 = open(".inTer2", "w")
-        file3 = open(".inTer3", "w")
+        with (
+            NamedTemporaryFile("w", delete_on_close=False) as file1,
+            NamedTemporaryFile("w", delete_on_close=False) as file2,
+            NamedTemporaryFile("w", delete_on_close=False) as file3,
+        ):
+            for h in range(len(fnt)):
+                if h == len(fnt) - 1:
+                    file1.write(fnt[h])
+                    file2.write(fun[h])
+                    file3.write(fds[h])
+                else:
+                    file1.write(fnt[h] + os.linesep)
+                    file2.write(fun[h] + os.linesep)
+                    file3.write(fds[h] + os.linesep)
 
-        for h in range(len(fnt)):
-            if h == len(fnt) - 1:
-                file1.write(fnt[h])
-                file2.write(fun[h])
-                file3.write(fds[h])
-            else:
-                file1.write(fnt[h] + os.linesep)
-                file2.write(fun[h] + os.linesep)
-                file3.write(fds[h] + os.linesep)
+            file1.close()
+            file2.close()
+            file3.close()
 
-        file1.close()
-        file2.close()
-        file3.close()
+            fnt = file1.name
+            fun = file2.name
+            fds = file3.name
 
-        fnt = ".inTer1"
-        fun = ".inTer2"
-        fds = ".inTer3"
+            if isinstance(self.geos, Geo00):
+                creattee_inter.crear_int0(
+                    startlat,
+                    startlon,
+                    deltalat,
+                    deltalon,
+                    fnt,
+                    fci,
+                    fun,
+                    fds,
+                    flv,
+                    ns,
+                    va,
+                )
 
-        if isinstance(self.geos, Geo00):
-            creattee_inter.crear_int0(
-                startlat, startlon, deltalat, deltalon, fnt, fci, fun, fds, flv, ns, va
-            )
+            elif isinstance(self.geos, Geo01):
+                creattee_inter.crear_int1(
+                    startlat, startlon, dx, dy, tlat1, fnt, fci, fun, fds, flv, ns, va
+                )
 
-        elif isinstance(self.geos, Geo01):
-            creattee_inter.crear_int1(
-                startlat, startlon, dx, dy, tlat1, fnt, fci, fun, fds, flv, ns, va
-            )
+            elif isinstance(self.geos, Geo03):
+                creattee_inter.crear_int3(
+                    startlat,
+                    startlon,
+                    dx,
+                    dy,
+                    xlonc,
+                    tlat1,
+                    tlat2,
+                    iswin,
+                    fnt,
+                    fci,
+                    fun,
+                    fds,
+                    flv,
+                    ns,
+                    va,
+                )
 
-        elif isinstance(self.geos, Geo03):
-            creattee_inter.crear_int3(
-                startlat,
-                startlon,
-                dx,
-                dy,
-                xlonc,
-                tlat1,
-                tlat2,
-                iswin,
-                fnt,
-                fci,
-                fun,
-                fds,
-                flv,
-                ns,
-                va,
-            )
+            elif isinstance(self.geos, Geo04):
+                creattee_inter.crear_int4(
+                    startlat,
+                    startlon,
+                    nlats,
+                    deltalon,
+                    iswin,
+                    fnt,
+                    fci,
+                    fun,
+                    fds,
+                    flv,
+                    ns,
+                    va,
+                )
 
-        elif isinstance(self.geos, Geo04):
-            creattee_inter.crear_int4(
-                startlat,
-                startlon,
-                nlats,
-                deltalon,
-                iswin,
-                fnt,
-                fci,
-                fun,
-                fds,
-                flv,
-                ns,
-                va,
-            )
-
-        elif isinstance(self.geos, Geo05):
-            creattee_inter.crear_int5(
-                startlat,
-                startlon,
-                dx,
-                dy,
-                xlonc,
-                tlat1,
-                iswin,
-                fnt,
-                fci,
-                fun,
-                fds,
-                flv,
-                ns,
-                va,
-            )
+            elif isinstance(self.geos, Geo05):
+                creattee_inter.crear_int5(
+                    startlat,
+                    startlon,
+                    dx,
+                    dy,
+                    xlonc,
+                    tlat1,
+                    iswin,
+                    fnt,
+                    fci,
+                    fun,
+                    fds,
+                    flv,
+                    ns,
+                    va,
+                )
 
         print(fname + ":" + hdate)
 
@@ -1032,7 +1044,6 @@ def chek_date(nome, dato):
 
 def cinter(filen, date, geoinfo, varias, rout="", nocolons=False):
     chek_date(filen, date)
-
 
     # if rout == "":
     #    pass

--- a/src/pywinter/winter.py
+++ b/src/pywinter/winter.py
@@ -156,9 +156,9 @@ class Interm:
         va = self.megamat
 
         with (
-            NamedTemporaryFile("w", delete_on_close=False) as file1,
-            NamedTemporaryFile("w", delete_on_close=False) as file2,
-            NamedTemporaryFile("w", delete_on_close=False) as file3,
+            NamedTemporaryFile("w", delete=False) as file1,
+            NamedTemporaryFile("w", delete=False) as file2,
+            NamedTemporaryFile("w", delete=False) as file3,
         ):
             for h in range(len(fnt)):
                 if h == len(fnt) - 1:

--- a/src/pywinter/winter.py
+++ b/src/pywinter/winter.py
@@ -262,6 +262,10 @@ class Interm:
                     va,
                 )
 
+        os.remove(fnt)
+        os.remove(fun)
+        os.remove(fds)
+        
         print(fname + ":" + hdate)
 
 

--- a/src/pywinter/winter.py
+++ b/src/pywinter/winter.py
@@ -195,7 +195,18 @@ class Interm:
 
             elif isinstance(self.geos, Geo01):
                 creattee_inter.crear_int1(
-                    startlat, startlon, dx, dy, tlat1, fnt, fci, fun, fds, flv, ns, va
+                    startlat,
+                    startlon,
+                    dx,
+                    dy,
+                    tlat1,
+                    fnt,
+                    fci,
+                    fun,
+                    fds,
+                    flv,
+                    ns,
+                    va
                 )
 
             elif isinstance(self.geos, Geo03):


### PR DESCRIPTION
Currently the library uses .inTer1, .inTer2, .inTer3 as temporary intermediate files. However, it causes problems when multiple programs using pywinter are run in parallel in the same working directory. I think that using NamedTemporaryFile is better.